### PR TITLE
Fix #45: Haus-Icon im Header statt 'Start'

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -200,6 +200,9 @@ i.text-primary { color: var(--brand-primary) !important; }
 /* Default color for all icons (Font Awesome, etc.) */
 i[class*="fa-"] { color: var(--brand-primary); }
 
+/* Ensure header nav icons follow link color (so hover/active behave like text) */
+.navbar .nav-link i{ color: currentColor; }
+
 /* Composed brand coloring */
 .navbar-brand .brand-composed{ display:inline-flex; gap:.4ch; align-items:baseline; font-weight:600; font-size:1.15rem; }
 .navbar-brand .brand-main{ color: var(--brand-dark); font-weight:700; letter-spacing:.5px; }

--- a/assets/js/lang.js
+++ b/assets/js/lang.js
@@ -203,7 +203,14 @@
     Object.entries(navMap).forEach(([sel,key])=>{
       const el = document.querySelector(sel);
       const val = getByPath(STATE.dict, key);
-      if (el && val) el.textContent = val;
+      if (!el || !val) return;
+      // If a nested label placeholder exists, populate that to preserve any icons
+      const childLabel = el.querySelector('[data-nav-label]');
+      if (childLabel){
+        childLabel.textContent = val;
+      } else {
+        el.textContent = val;
+      }
     });
     // Footer
     const footerMap = {

--- a/components/header.html
+++ b/components/header.html
@@ -37,7 +37,10 @@
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
         <li class="nav-item">
-          <a class="nav-link" id="nav-home" href="index.html"></a>
+          <a class="nav-link d-flex align-items-center gap-2" id="nav-home" href="index.html" aria-current="false">
+            <i class="fa-solid fa-house" aria-hidden="true"></i>
+            <span class="visually-hidden" data-nav-label></span>
+          </a>
         </li>
         <li class="nav-item">
           <a class="nav-link" id="nav-ueberuns" href="ueber-uns.html"


### PR DESCRIPTION
Fixes #45. Dieses PR ersetzt im Header-Navigationslink den Text 'Start' durch ein Haus-Icon (wie in den Breadcrumbs).